### PR TITLE
Normalize custom-domain make + flag missing mileage

### DIFF
--- a/src/VehicleListing/custom_domain_adapters/buckinghamautos.py
+++ b/src/VehicleListing/custom_domain_adapters/buckinghamautos.py
@@ -5,6 +5,7 @@ import re
 import requests
 
 from .base import DomainAdapter
+from ..make_normalizer import normalize_make
 
 logger = logging.getLogger("custom_domain")
 
@@ -219,12 +220,17 @@ class BuckinghamAutosAdapter(DomainAdapter):
         year = car.get("year")
         make = _normalize_make(car.get("make"))
         model = car.get("model")
+        # Canonicalise make → exact manufacturer name. Must match migration 0031.
+        make, model = normalize_make(make, model)
         badge = car.get("badge") or ""
         series = car.get("series") or ""
         variant = " ".join([badge, series]).strip() or None
 
         price = car.get("egcprice") or car.get("price")
-        mileage = car.get("km") or car.get("odometer_reading")
+        mileage = (
+            car.get("km") or car.get("odometer_reading")
+            or car.get("odometer") or car.get("kms") or car.get("kilometres")
+        )
         body_type = car.get("simple_body") or car.get("body")
         fuel_type = car.get("simple_fuel") or car.get("fuel")
         transmission = car.get("simple_transmission") or car.get("trans")

--- a/src/VehicleListing/custom_domain_adapters/dnacarsales.py
+++ b/src/VehicleListing/custom_domain_adapters/dnacarsales.py
@@ -9,6 +9,7 @@ from bs4 import BeautifulSoup
 from django.conf import settings
 
 from .base import DomainAdapter
+from ..make_normalizer import normalize_make
 
 logger = logging.getLogger("custom_domain")
 
@@ -177,6 +178,24 @@ def _parse_mileage(text):
     return int(digits) if digits else None
 
 
+def _find_odometer(spec):
+    """Best-effort odometer lookup. Prefer the exact 'Odometer' label, then
+    fall back to any spec row whose label looks like an odometer
+    (odometer / kilometres / kms / mileage) so a slightly different label
+    doesn't leave the listing with no mileage. Restricted to odometer-like
+    labels so we never mistake an unrelated number (doors, engine size) for it.
+    """
+    if spec.get("Odometer"):
+        return _parse_mileage(spec.get("Odometer"))
+    for key, value in spec.items():
+        k = (key or "").lower()
+        if "odom" in k or "kilom" in k or k == "kms" or "mileage" in k:
+            parsed = _parse_mileage(value)
+            if parsed is not None:
+                return parsed
+    return None
+
+
 def _absolute_image_url(src):
     if not src:
         return None
@@ -279,6 +298,10 @@ class DNACarSalesAdapter(DomainAdapter):
         make = _normalize_make(parts[1]) if len(parts) > 1 else None
         model = parts[2] if len(parts) > 2 else None
         variant = " ".join(parts[3:]) if len(parts) > 3 else None
+        # Canonicalise make → exact manufacturer name (FB "Other" category fix);
+        # recovers split multi-word brands ("Land"/"Rover" → "Land Rover") by
+        # borrowing from model. Must match migration 0031 byte-for-byte.
+        make, model = normalize_make(make, model)
 
         price_node = soup.select_one("#details-vehicle-info-vehicle-Price")
         price = _parse_price(price_node.get_text(strip=True)) if price_node else None
@@ -298,7 +321,7 @@ class DNACarSalesAdapter(DomainAdapter):
         fuel_type = _normalize_fuel(spec.get("Fuel"))
         color = _normalize_color(spec.get("Colour"))
         transmission = _normalize_transmission(spec.get("Transmission"))
-        mileage = _parse_mileage(spec.get("Odometer"))
+        mileage = _find_odometer(spec)
 
         images = []
         for img in soup.select("ul.bxslider img"):

--- a/src/VehicleListing/custom_domain_adapters/generic_jsonld.py
+++ b/src/VehicleListing/custom_domain_adapters/generic_jsonld.py
@@ -23,6 +23,7 @@ import requests
 from bs4 import BeautifulSoup
 
 from .base import DomainAdapter, normalize_au_state
+from ..make_normalizer import normalize_make
 
 logger = logging.getLogger("custom_domain")
 
@@ -370,11 +371,16 @@ def _parse_via_carssr(html: str, stock_url: str, listing_id: str) -> dict | None
     year = car.get("year")
     make = car.get("make")
     model = car.get("model")
+    # Canonicalise make → exact manufacturer name. Must match migration 0031.
+    make, model = normalize_make(make, model)
     badge = car.get("badge") or ""
     series = car.get("series") or ""
     variant = " ".join(p for p in (badge, series) if p).strip() or None
     price = car.get("egcprice") or car.get("price")
-    mileage = car.get("km") or car.get("odometer_reading")
+    mileage = (
+        car.get("km") or car.get("odometer_reading")
+        or car.get("odometer") or car.get("kms") or car.get("kilometres")
+    )
     body_type = car.get("simple_body") or car.get("body")
     fuel_type = car.get("simple_fuel") or car.get("fuel")
     transmission = car.get("simple_transmission") or car.get("trans")
@@ -719,6 +725,8 @@ class GenericJsonLdAdapter(DomainAdapter):
             _unwrap_name(vehicle.get("model"))
             or _unwrap_name(vehicle.get("vehicleModel"))
         )
+        # Canonicalise make → exact manufacturer name. Must match migration 0031.
+        make, model = normalize_make(make, model)
         year = _extract_year(vehicle)
         price = _extract_price(vehicle)
         mileage = _extract_mileage(vehicle)

--- a/src/VehicleListing/custom_domain_scraper.py
+++ b/src/VehicleListing/custom_domain_scraper.py
@@ -101,6 +101,9 @@ def _apply_listing_update(existing, result):
     existing.variant = result.get("variant")
     existing.price = str(result.get("price")) if result.get("price") is not None else existing.price
     existing.mileage = result.get("mileage")
+    # Flag rows with no usable odometer (None/0) so the duplicate-matcher
+    # knows mileage can't be used as a tie-breaker for this listing.
+    existing.mileage_unavailable = result.get("mileage") in (None, 0)
     existing.transmission = result.get("transmission")
     existing.description = result.get("description")
     existing.images = result.get("image")
@@ -192,6 +195,7 @@ def custom_domain_profile_listings_thread(stock_links, profile_instance, user, p
                         variant=result.get("variant"),
                         make=result.get("make"),
                         mileage=result.get("mileage"),
+                        mileage_unavailable=result.get("mileage") in (None, 0),
                         model=result.get("model"),
                         price=str(result.get("price")) if result.get("price") is not None else None,
                         transmission=result.get("transmission"),

--- a/src/VehicleListing/make_normalizer.py
+++ b/src/VehicleListing/make_normalizer.py
@@ -1,0 +1,152 @@
+"""Canonical manufacturer normalisation for custom-domain listings.
+
+Facebook Marketplace's vehicle form only accepts an exact manufacturer name in
+the ``make`` field. Anything else — a model glued onto the make
+("Toyota Hiace"), a split multi-word brand ("Land" for "Land Rover"), or a
+blank — drops the car into the generic "Other" category, which is why those
+listings render broken. Custom-domain scrapers derive ``make`` from free-form
+page text, so we canonicalise it here.
+
+This helper is the single source of truth used in TWO places that MUST agree:
+
+  * at ingest, by the custom-domain adapters (DNA / Buckingham / generic), and
+  * by migration ``0031_normalize_custom_domain_make``, which repairs the rows
+    already in the table.
+
+They must produce byte-identical (make, model) for the same input. The
+custom-domain re-scrape change-detector compares the stored row against the
+freshly-scraped values (see ``custom_domain_scraper._apply_listing_update`` /
+the field comparison around it); if the migration normalised a stored row but
+ingest produced a different value, the comparator would see a phantom change,
+set ``is_changed=True``, and trigger a delete+republish — recreating the
+duplicate loop. Calling the same function from both sides guarantees they match.
+
+Gumtree is deliberately NOT covered here. It is the production revenue path and
+its make extraction + change-detector are out of scope for this change.
+"""
+
+# Canonical manufacturer spellings (the exact casing Facebook Marketplace
+# accepts). Multi-word brands MUST appear here so a brand the source split
+# across make/model (e.g. make="Land", model="Rover ...") is recovered by the
+# combined-token lookup in ``resolve_make`` without needing a special alias.
+VALID_MAKES = {
+    'Abarth', 'Alfa Romeo', 'Alpina', 'Alpine', 'Alvis', 'Armstrong Whitworth',
+    'Aston Martin', 'Audi', 'Austin', 'BMW', 'BRP', 'BYD', 'Bentley', 'Bolwell',
+    'Bufori', 'Caterham', 'Chery', 'Chevrolet', 'Chrysler', 'Citroën', 'Cupra',
+    'DKW', 'DS', 'Daewoo', 'Daihatsu', 'Daimler', 'DeSoto', 'Delahaye', 'Dodge',
+    'Dover', 'Elfin', 'Eunos', 'FIAT', 'FPV', 'Facel Vega', 'Ferrari',
+    'Fleetwood', 'Ford', 'Foton', 'Franklin', 'Frazer Nash', 'GMC', 'GWM',
+    'Geely', 'Genesis', 'Great Wall', 'HINO', 'HSV', 'Haval', 'Holden', 'Honda',
+    'Hudson', 'Hummer', 'Hyundai', 'INFINITI', 'Isuzu', 'Iveco', 'JMC', 'Jaguar',
+    'Jeep', 'Jewett', 'Kia', 'LDV', 'Lada', 'Lamborghini', 'Land Rover', 'Lexus',
+    'Leyland', 'Lotus', 'MG', 'MINI', 'Mahindra', 'Maserati', 'Maybach', 'Mazda',
+    'McLaren', 'Mercedes-Benz', 'Minerva', 'Mitsubishi', 'Morgan', 'Morris',
+    'NSU', 'Nash', 'Nissan', 'Noble', 'Opel', 'Option RV', 'Packard', 'Pagani',
+    'Panther', 'Peugeot', 'Pierce-Arrow', 'Plymouth', 'Polestar', 'Pontiac',
+    'Porsche', 'Proton', 'Python', 'Rambler', 'Renault', 'Riley', 'Rolls-Royce',
+    'Rover', 'SEAT', 'Saab', 'Shelby', 'Smart', 'Sparks', 'Ssangyong',
+    'Studebaker', 'Subaru', 'Superformance', 'Suzuki', 'Swallow', 'Swift', 'TVR',
+    'Tata', 'Tatra', 'Tesla', 'Toyota', 'Triumph', 'Universal', 'Volkswagen',
+    'Volvo', 'Willys', 'Wolseley', 'ZX Auto', 'Škoda',
+}
+
+# Aliases / common spellings → canonical. Only needed where the source spelling
+# is NOT a leading prefix of the canonical name (e.g. "Range" for "Land Rover",
+# "VW" for "Volkswagen"); plain multi-word brands are handled by the canonical
+# list above.
+ALIASES = {
+    'vw': 'Volkswagen',
+    'chevy': 'Chevrolet',
+    'merc': 'Mercedes-Benz',
+    'mercedes': 'Mercedes-Benz',
+    'mercedes benz': 'Mercedes-Benz',
+    'range': 'Land Rover',
+    'range rover': 'Land Rover',
+    'rolls royce': 'Rolls-Royce',
+    'mini cooper': 'MINI',
+    'citroen': 'Citroën',
+    'skoda': 'Škoda',
+    'great wall motors': 'Great Wall',
+    'gwm haval': 'GWM',
+    'isuzu ute': 'Isuzu',
+}
+
+# Lowercase lookup covering every canonical make plus the aliases above.
+KNOWN = {m.lower(): m for m in VALID_MAKES}
+KNOWN.update(ALIASES)
+
+# Brands that are stored all-caps; used only for the cosmetic fallback when a
+# make can't be resolved, so we don't title-case a genuine acronym into "Bmw".
+_ACRONYMS = {
+    'BMW', 'MG', 'HSV', 'VW', 'GMC', 'DAF', 'BYD', 'MAN', 'SAAB', 'LDV', 'RAM',
+    'FIAT', 'FPV', 'HINO', 'JMC', 'NSU', 'SEAT', 'TVR', 'BRP', 'DS', 'DKW',
+    'GWM', 'MINI', 'INFINITI',
+}
+
+
+def _light_clean(make):
+    """Cosmetic-only cleanup for makes we can't resolve to the canonical list.
+
+    Never moves tokens between make and model — an unresolved make is returned
+    recognisably intact so the migration can flag it for review rather than
+    silently rewriting something we don't understand.
+    """
+    raw = (make or '').strip()
+    if not raw:
+        return raw
+    if raw.upper() in _ACRONYMS:
+        return raw.upper()
+    return raw.title()
+
+
+def resolve_make(make, model):
+    """Resolve ``make`` to a canonical manufacturer name.
+
+    Returns ``(make, model, resolved)``:
+
+    * ``resolved=True``  — ``make`` is a canonical name and any tokens that
+      belonged elsewhere have been moved into ``model`` (extra words glued onto
+      a make are pushed into model; words borrowed to complete a split
+      multi-word brand are removed from model).
+    * ``resolved=False`` — ``make``/``model`` are returned unchanged in meaning
+      (the caller decides whether to apply a cosmetic clean or flag the row).
+
+    The token stream is ``make`` tokens followed by ``model`` tokens, so a brand
+    the source split across the two fields (make="Land", model="Rover ...") is
+    recovered by matching the longest leading canonical prefix.
+    """
+    make_s = (make or '').strip()
+    model_s = (model or '').strip()
+    if not make_s:
+        return make_s, model_s, False
+
+    make_tokens = make_s.split()
+    model_tokens = model_s.split()
+    combined = make_tokens + model_tokens
+
+    for n in range(min(3, len(combined)), 0, -1):
+        key = ' '.join(combined[:n]).lower()
+        if key in KNOWN:
+            canonical = KNOWN[key]
+            consumed_from_model = max(0, n - len(make_tokens))
+            leftover_make = make_tokens[n:] if n < len(make_tokens) else []
+            new_model_tokens = leftover_make + model_tokens[consumed_from_model:]
+            return canonical, ' '.join(new_model_tokens).strip(), True
+
+    return make_s, model_s, False
+
+
+def normalize_make(make, model):
+    """Ingest-side wrapper: return canonicalised ``(make, model)``.
+
+    Preserves a null/blank make as-is (so the change-detector and the
+    nullable column don't flip between ``None`` and ``""``). Resolved makes get
+    the canonical value + adjusted model; unresolved makes get a cosmetic clean
+    only, with model untouched.
+    """
+    if not (make or '').strip():
+        return make, model
+    canonical, new_model, resolved = resolve_make(make, model)
+    if resolved:
+        return canonical, new_model
+    return _light_clean(make), model

--- a/src/VehicleListing/migrations/0031_normalize_custom_domain_make.py
+++ b/src/VehicleListing/migrations/0031_normalize_custom_domain_make.py
@@ -1,0 +1,75 @@
+"""Repair existing custom-domain rows whose `make` isn't a clean manufacturer
+name (model glued on, split multi-word brand, wrong casing) — the values that
+drop a Facebook Marketplace listing into the generic "Other" category.
+
+Scope is custom-domain rows ONLY (`custom_domain_profile` set, `gumtree_profile`
+unset). Gumtree is the production revenue path and is deliberately excluded.
+
+Uses the same `resolve_make` as the custom-domain adapters, so a repaired row
+matches what a fresh scrape now produces — otherwise the re-scrape
+change-detector would see a phantom change and re-flag `is_changed`, recreating
+the duplicate loop. Rows whose make can't be resolved to a known manufacturer
+are left untouched and counted as `unresolved` in the deploy log for a human to
+review (typically blank/unknown makes); nothing is silently corrupted.
+"""
+from django.db import migrations
+
+from VehicleListing.make_normalizer import VALID_MAKES, resolve_make
+
+
+def forwards(apps, schema_editor):
+    VehicleListing = apps.get_model("VehicleListing", "VehicleListing")
+
+    rows = VehicleListing.objects.filter(
+        custom_domain_profile__isnull=False,
+        gumtree_profile__isnull=True,
+    )
+
+    fixed = unresolved = unchanged = errored = 0
+    for row in rows.iterator():
+        try:
+            canonical, new_model, resolved = resolve_make(row.make, row.model)
+            if not resolved:
+                # Already a clean canonical name → fine; otherwise it's a
+                # blank/unknown make a human needs to set.
+                if (row.make or "") not in VALID_MAKES:
+                    unresolved += 1
+                else:
+                    unchanged += 1
+                continue
+
+            update_fields = []
+            if row.make != canonical:
+                row.make = canonical
+                update_fields.append("make")
+            if (row.model or "") != new_model:
+                row.model = new_model
+                update_fields.append("model")
+
+            if update_fields:
+                # Note: updated_at (auto_now) is intentionally NOT listed, so the
+                # repair doesn't reshuffle the `-updated_at` listing feeds.
+                row.save(update_fields=update_fields)
+                fixed += 1
+            else:
+                unchanged += 1
+        except Exception as exc:  # never let one bad row abort the migration
+            errored += 1
+            print(f"[normalize_custom_domain_make] row id={row.pk} skipped: {exc}")
+
+    print(
+        "[normalize_custom_domain_make] "
+        f"fixed={fixed} unchanged={unchanged} "
+        f"unresolved(blank/unknown, review in admin)={unresolved} errored={errored}"
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("VehicleListing", "0030_vehiclelisting_facebook_listing_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, migrations.RunPython.noop),
+    ]

--- a/src/VehicleListing/migrations/0032_vehiclelisting_mileage_unavailable.py
+++ b/src/VehicleListing/migrations/0032_vehiclelisting_mileage_unavailable.py
@@ -1,0 +1,42 @@
+"""Add `mileage_unavailable` and backfill it for existing custom-domain rows.
+
+Mileage is the tie-breaker the extension uses to distinguish several cars that
+share a title. Custom-domain sources sometimes omit the odometer, leaving
+mileage null/0; this flag marks those rows so they aren't treated as
+distinguishable. Backfill is scoped to custom-domain rows only — Gumtree rows
+always carry a parsed odometer and keep the default (False).
+"""
+from django.db import migrations, models
+
+
+def backfill(apps, schema_editor):
+    VehicleListing = apps.get_model("VehicleListing", "VehicleListing")
+    rows = VehicleListing.objects.filter(
+        custom_domain_profile__isnull=False,
+        gumtree_profile__isnull=True,
+    )
+    flagged = 0
+    for row in rows.iterator():
+        unavailable = row.mileage is None or row.mileage == 0
+        if unavailable != row.mileage_unavailable:
+            row.mileage_unavailable = unavailable
+            row.save(update_fields=["mileage_unavailable"])
+            if unavailable:
+                flagged += 1
+    print(f"[mileage_unavailable backfill] custom-domain rows flagged={flagged}")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("VehicleListing", "0031_normalize_custom_domain_make"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="vehiclelisting",
+            name="mileage_unavailable",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(backfill, migrations.RunPython.noop),
+    ]

--- a/src/VehicleListing/models.py
+++ b/src/VehicleListing/models.py
@@ -77,6 +77,13 @@ class VehicleListing(models.Model):
     model = models.CharField(max_length=100,null=True,blank=True)
     price = models.CharField(max_length=255,null=True,blank=True)
     mileage = models.IntegerField(null=True,blank=True)
+    # True when a custom-domain scrape could not determine a usable odometer
+    # (missing or 0). Mileage is the tie-breaker the extension uses to tell
+    # apart several cars that share a title; this flag marks the rows where
+    # that signal isn't available so they aren't treated as distinguishable.
+    # Gumtree rows always carry a parsed odometer (the scrape drops a listing
+    # rather than store it blank), so this stays False for them.
+    mileage_unavailable = models.BooleanField(default=False)
     exterior_colour = models.CharField(max_length=255,null=True,blank=True)
     interior_colour = models.CharField(max_length=255,null=True,blank=True)
     description = models.TextField(null=True,blank=True)

--- a/src/VehicleListing/views.py
+++ b/src/VehicleListing/views.py
@@ -1499,90 +1499,135 @@ def update_vehicle_listing_is_changed(request):
         }, status=500)
 
 
-@api_view(['PATCH'])
+@api_view(['PATCH', 'DELETE'])
 @permission_classes([IsAuthenticated])
 def update_vehicle_listing_facebook_id(request):
     """
-    Store the Facebook Marketplace listing ID for a VehicleListing.
+    Manage the Facebook Marketplace listing ID for a VehicleListing.
 
-    Overwrite-on-each-call (1:1 with VehicleListing — no history kept).
-    Used by the extension to enable targeted deletes via the FB ID
-    instead of fragile title-search deletes.
+    PATCH — store/overwrite the ID (1:1 with VehicleListing — no history kept).
+            Used by the extension to enable targeted deletes via the FB ID
+            instead of fragile title-search deletes.
 
-    Request Body:
-    {
-        "id": 123,
-        "facebook_listing_id": "1234567890123456"
-    }
+        Request Body: { "id": 123, "facebook_listing_id": "1234567890123456" }
+        Returns:      { "success": true,
+                        "data": { "id": 123, "facebook_listing_id": "1234567890123456" } }
 
-    Returns:
-    {
-        "success": true,
-        "data": { "id": 123, "facebook_listing_id": "1234567890123456" }
-    }
+    DELETE — clear the ID back to null (e.g. after the listing is removed from
+             Facebook). Idempotent: clearing an already-null field still 200s.
+
+        Request Body: { "id": 123 }
+        Returns:      { "success": true,
+                        "data": { "id": 123, "facebook_listing_id": null } }
+
+    Every call is logged to the `relister_views` logger — entry, each rejection
+    reason, and the final outcome — so we can diagnose why the extension's
+    writes do or don't land (the column was at 0/971 populated as of this change).
     """
+    # Some clients send DELETE without a Content-Type; tolerate an empty body.
+    raw_body = request.body or b''
+    logger.info(
+        "facebook-id %s by user=%s body_len=%s",
+        request.method, getattr(request.user, 'email', request.user), len(raw_body),
+    )
     try:
-        data = json.loads(request.body)
+        data = json.loads(raw_body) if raw_body else {}
+        if not isinstance(data, dict):
+            logger.warning("facebook-id %s rejected: body is not a JSON object", request.method)
+            return JsonResponse({
+                'success': False,
+                'error': 'Request body must be a JSON object'
+            }, status=400)
+
+        logger.info(
+            "facebook-id %s payload: id=%r (%s) facebook_listing_id=%r (%s)",
+            request.method,
+            data.get('id'), type(data.get('id')).__name__,
+            data.get('facebook_listing_id'), type(data.get('facebook_listing_id')).__name__,
+        )
 
         if 'id' not in data:
+            logger.warning("facebook-id %s rejected: 'id' missing", request.method)
             return JsonResponse({
                 'success': False,
                 'error': 'Vehicle listing ID is required'
             }, status=400)
 
-        if 'facebook_listing_id' not in data:
-            return JsonResponse({
-                'success': False,
-                'error': 'facebook_listing_id is required'
-            }, status=400)
-
-        vehicle_listing_id = data['id']
-        facebook_listing_id = data['facebook_listing_id']
-
         # Validate ID
+        vehicle_listing_id = data['id']
         try:
             vehicle_listing_id = int(vehicle_listing_id)
             if vehicle_listing_id <= 0:
                 raise ValueError("ID must be positive")
         except (ValueError, TypeError):
+            logger.warning("facebook-id %s rejected: invalid id %r", request.method, data.get('id'))
             return JsonResponse({
                 'success': False,
                 'error': 'Invalid vehicle listing ID format'
             }, status=400)
 
-        # facebook_listing_id must be a non-empty string within the model's max_length.
-        if not isinstance(facebook_listing_id, str):
-            return JsonResponse({
-                'success': False,
-                'error': 'facebook_listing_id must be a string'
-            }, status=400)
+        # DELETE clears the field; PATCH sets it. Resolve the value to store first
+        # so the lookup/save tail is shared between both verbs.
+        if request.method == 'DELETE':
+            facebook_listing_id = None
+        else:
+            if 'facebook_listing_id' not in data:
+                logger.warning("facebook-id PATCH rejected: 'facebook_listing_id' missing (id=%s)", vehicle_listing_id)
+                return JsonResponse({
+                    'success': False,
+                    'error': 'facebook_listing_id is required'
+                }, status=400)
 
-        facebook_listing_id = facebook_listing_id.strip()
-        if not facebook_listing_id:
-            return JsonResponse({
-                'success': False,
-                'error': 'facebook_listing_id must not be empty'
-            }, status=400)
+            facebook_listing_id = data['facebook_listing_id']
 
-        if len(facebook_listing_id) > 128:
-            return JsonResponse({
-                'success': False,
-                'error': 'facebook_listing_id exceeds maximum length of 128 characters'
-            }, status=400)
+            # facebook_listing_id must be a non-empty string within the model's max_length.
+            if not isinstance(facebook_listing_id, str):
+                logger.warning(
+                    "facebook-id PATCH rejected: facebook_listing_id not a string (id=%s, type=%s)",
+                    vehicle_listing_id, type(facebook_listing_id).__name__,
+                )
+                return JsonResponse({
+                    'success': False,
+                    'error': 'facebook_listing_id must be a string'
+                }, status=400)
+
+            facebook_listing_id = facebook_listing_id.strip()
+            if not facebook_listing_id:
+                logger.warning("facebook-id PATCH rejected: facebook_listing_id empty (id=%s)", vehicle_listing_id)
+                return JsonResponse({
+                    'success': False,
+                    'error': 'facebook_listing_id must not be empty'
+                }, status=400)
+
+            if len(facebook_listing_id) > 128:
+                logger.warning("facebook-id PATCH rejected: facebook_listing_id too long (id=%s)", vehicle_listing_id)
+                return JsonResponse({
+                    'success': False,
+                    'error': 'facebook_listing_id exceeds maximum length of 128 characters'
+                }, status=400)
 
         vehicle_listing = VehicleListing.objects.filter(
             id=vehicle_listing_id, user=request.user
         ).first()
         if vehicle_listing is None:
+            logger.warning(
+                "facebook-id %s 404: listing id=%s not found for user=%s",
+                request.method, vehicle_listing_id, getattr(request.user, 'email', request.user),
+            )
             return JsonResponse({
                 'success': False,
                 'error': 'Vehicle listing not found or you do not have permission to update it'
             }, status=404)
 
-        # Overwrite-on-call. Explicit update_fields keeps this surgical.
+        # Overwrite-on-call (PATCH) / clear-to-null (DELETE). Explicit
+        # update_fields keeps this surgical and avoids touching scrape data.
         vehicle_listing.facebook_listing_id = facebook_listing_id
         vehicle_listing.save(update_fields=['facebook_listing_id', 'updated_at'])
 
+        logger.info(
+            "facebook-id %s ok: listing id=%s facebook_listing_id=%r",
+            request.method, vehicle_listing.id, vehicle_listing.facebook_listing_id,
+        )
         return JsonResponse({
             'success': True,
             'data': {
@@ -1592,6 +1637,7 @@ def update_vehicle_listing_facebook_id(request):
         }, status=200)
 
     except json.JSONDecodeError:
+        logger.warning("facebook-id %s rejected: invalid JSON body", request.method)
         return JsonResponse({
             'success': False,
             'error': 'Invalid JSON format in request body'


### PR DESCRIPTION
Make: add shared make_normalizer (canonical manufacturer list + aliases, recovers split multi-word brands, moves leftover tokens to model), wire into DNA/Buckingham/generic adapters, and repair existing rows via migration 0031. Fixes cars landing in Facebook's "Other" category from dirty make values.

Mileage: add `mileage_unavailable` flag (true when odometer is missing/0) so the extension's duplicate matcher knows when mileage isn't a usable tie-breaker; broaden odometer capture to alternate source labels; backfill existing rows via migration 0032.

Ingest and migrations share the same helpers so re-scrapes match repaired rows and don't trip the is_changed change-detector.